### PR TITLE
DEVOPS-58 Fix path in build stage in project's Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
                         cp -R ${WORKSPACE}/${DOC_PROJECT}/api ${WORKSPACE}/argoeu
                         cp -R ${WORKSPACE}/${DOC_PROJECT}/messaging ${WORKSPACE}/argoeu
                         cp -R ${WORKSPACE}/${DOC_PROJECT}/authn ${WORKSPACE}/argoeu
-                        cp -R ${WORKSPACE}/argo-ams-library/_build/ ${WORKSPACE}/argoeu/ams-library
+                        cp -R ${WORKSPACE}/argo-ams-library/documentation/_build/ ${WORKSPACE}/argoeu/ams-library
                         cd ${WORKSPACE}/argoeu
                         if [ -n "\$(git status --porcelain)" ]; then
                             git add -A


### PR DESCRIPTION
Fix path to correctly copy generated doc files to designated destination folder. This error caused build to fail